### PR TITLE
Add job support sub-agents and broaden task prompt

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,1 @@
+"""Core agent package for Accessible Solutions."""

--- a/agents/deepagent/__init__.py
+++ b/agents/deepagent/__init__.py
@@ -5,6 +5,7 @@ from .sub_agent import SubAgent, _create_task_tool
 from .tools import write_todos, write_file, read_file, ls, edit_file
 from langchain_core.tools import BaseTool
 from langchain_core.language_models import LanguageModelLike
+from .supervisor_agent import get_supervisor_agent
 
 __all__ = [
     "create_deep_agent",
@@ -21,4 +22,5 @@ __all__ = [
     "edit_file",
     "BaseTool",
     "LanguageModelLike",
+    "get_supervisor_agent",
 ]

--- a/agents/deepagent/prompts.py
+++ b/agents/deepagent/prompts.py
@@ -188,6 +188,8 @@ TASK_DESCRIPTION_PREFIX = """Launch a new agent to handle complex, multi-step ta
 Available agent types and the tools they have access to:
 - general-purpose: General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. (Tools: *)
 {other_agents}
+
+These specialized agents can assist with tasks beyond research, such as finding community resources or helping with job applications.
 """
 
 TASK_DESCRIPTION_SUFFIX = """When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.

--- a/agents/deepagent/supervisor_agent.py
+++ b/agents/deepagent/supervisor_agent.py
@@ -1,0 +1,97 @@
+import os
+from typing import Dict, Any, Literal
+from tavily import TavilyClient
+from langchain_core.tools import tool
+
+from .graph import create_deep_agent
+from .sub_agent import SubAgent
+from ..resources.search import search_for_agencies
+from ..resources.chat import display_agencies
+from ..tools.frontend_actions import (
+    show_resume_builder,
+    update_resume_data,
+    show_cover_letter_builder,
+)
+
+
+@tool
+def internet_search(
+    query: str,
+    max_results: int = 5,
+    topic: Literal["general", "news", "finance"] = "general",
+    include_raw_content: bool = False,
+) -> Dict[str, Any]:
+    """Run a web search using Tavily."""
+    api_key = os.getenv("TAVILY_API_KEY", "")
+    client = TavilyClient(api_key=api_key)
+    return client.search(
+        query=query,
+        max_results=max_results,
+        search_depth="advanced",
+        include_raw_content=include_raw_content,
+        topic=topic,
+    )
+
+
+resources_sub_agent: SubAgent = {
+    "name": "resources-agent",
+    "description": "Finds local resources such as food banks or shelters.",
+    "prompt": (
+        "You help users locate local social service agencies. "
+        "Use search_for_agencies to look up resources and display_agencies to show results."
+    ),
+    "tools": ["search_for_agencies", "display_agencies"],
+}
+
+resume_builder_sub_agent: SubAgent = {
+    "name": "resume-builder",
+    "description": "Guides users through creating a professional resume.",
+    "prompt": (
+        "Assist the user with building a resume. "
+        "Use show_resume_builder to open the form and update_resume_data to fill sections."
+    ),
+    "tools": ["show_resume_builder", "update_resume_data"],
+}
+
+job_research_sub_agent: SubAgent = {
+    "name": "job-research",
+    "description": "Researches jobs, companies, or industries for the user.",
+    "prompt": (
+        "Perform job or company research and summarize findings for the user. "
+        "Use internet_search to gather information."
+    ),
+    "tools": ["internet_search"],
+}
+
+cover_letter_sub_agent: SubAgent = {
+    "name": "cover-letter-builder",
+    "description": "Helps users craft personalized cover letters.",
+    "prompt": (
+        "Assist the user in writing a tailored cover letter. "
+        "Use show_cover_letter_builder to display the form for editing."
+    ),
+    "tools": ["show_cover_letter_builder"],
+}
+
+
+def get_supervisor_agent():
+    """Return the main agent with access to specialized sub-agents."""
+    tools = [
+        search_for_agencies,
+        display_agencies,
+        show_resume_builder,
+        update_resume_data,
+        show_cover_letter_builder,
+        internet_search,
+    ]
+    subagents = [
+        resources_sub_agent,
+        resume_builder_sub_agent,
+        job_research_sub_agent,
+        cover_letter_sub_agent,
+    ]
+    instructions = (
+        "You are a helpful assistant who can delegate complex tasks to specialized agents "
+        "for researching jobs, finding community resources, and creating application materials."
+    )
+    return create_deep_agent(tools, instructions, subagents=subagents)

--- a/agents/prompts.py
+++ b/agents/prompts.py
@@ -188,6 +188,8 @@ TASK_DESCRIPTION_PREFIX = """Launch a new agent to handle complex, multi-step ta
 Available agent types and the tools they have access to:
 - general-purpose: General-purpose agent for researching complex questions, searching for files and content, and executing multi-step tasks. When you are searching for a keyword or file and are not confident that you will find the right match in the first few tries use this agent to perform the search for you. (Tools: *)
 {other_agents}
+
+These specialized agents can assist with tasks beyond research, such as finding community resources or helping with job applications.
 """
 
 TASK_DESCRIPTION_SUFFIX = """When using the Task tool, you must specify a subagent_type parameter to select which agent type to use.

--- a/agents/tools/__init__.py
+++ b/agents/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Shared tools for agent interactions."""

--- a/agents/tools/frontend_actions.py
+++ b/agents/tools/frontend_actions.py
@@ -1,0 +1,20 @@
+from typing import Optional, Dict, Any
+from langchain_core.tools import tool
+
+
+@tool
+def show_resume_builder(prefill_data: Optional[Dict[str, Any]] = None) -> str:
+    """Display the resume builder form to the user."""
+    return "Displayed resume builder form"
+
+
+@tool
+def update_resume_data(section: str, data: Dict[str, Any], item_id: Optional[str] = None, action: str = "update") -> str:
+    """Update or modify sections of the resume builder form."""
+    return f"Updated resume section {section}"
+
+
+@tool
+def show_cover_letter_builder(job_title: Optional[str] = None, company_name: Optional[str] = None) -> str:
+    """Display the cover letter builder form to the user."""
+    return "Displayed cover letter builder form"


### PR DESCRIPTION
## Summary
- add frontend action tools and supervisor agent supporting resources, resume building, job research, and cover letter creation
- allow main prompt to mention sub-agents for tasks beyond research

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f4f3a274c832a94c2706d04daad39